### PR TITLE
[Xtensa] Pass pointers as-is in the Xtensa ABI (LLVM-84)

### DIFF
--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -9851,6 +9851,9 @@ ABIArgInfo XtensaABIInfo::classifyArgumentType(QualType Ty,
     // Treat an enum type as its underlying type.
     if (const EnumType *EnumTy = Ty->getAs<EnumType>())
       Ty = EnumTy->getDecl()->getIntegerType();
+    // Pointers can be passed as-is.
+    if (Ty->isPointerType())
+      return ABIArgInfo::getDirect();
     // All integral types are promoted to XLen width, unless passed on the
     // stack.
     if (Size < 32 && Ty->isIntegralOrEnumerationType() && !MustUseStack) {


### PR DESCRIPTION
Previously, pointers were cast to `i32` integers when passed as arguments to a function or when they are returned. However, this appears to break the assumption that malloclike functions (such as `malloc` with the right attribute) return a pointer, not an integer.

This patch makes sure plain pointers are not coerced in any way and instead are passed simply as pointers.

Fixes the crash in #34. I haven't run any tests yet as I hit another bug trying to compile picolibc.