### PR TITLE
[Xtensa] Remove unnecessary MOVSP in epilogue.

### DIFF
--- a/llvm/lib/Target/Xtensa/XtensaFrameLowering.cpp
+++ b/llvm/lib/Target/Xtensa/XtensaFrameLowering.cpp
@@ -245,8 +245,13 @@ void XtensaFrameLowering::emitEpilogue(MachineFunction &MF,
     for (unsigned i = 0; i < MFI.getCalleeSavedInfo().size(); ++i)
       --I;
     if (STI.isWinABI()) {
-      // Insert instruction "movsp $sp, $fp" at this location.
-      BuildMI(MBB, I, dl, TII.get(Xtensa::MOVSP), SP).addReg(FP);
+      // In most architectures, we need to explicitly restore the stack pointer
+      // before returning.
+      //
+      // For Xtensa Windowed Register option, it is not needed to explicitly
+      // restore the stack pointer. Reason being is that on function return,
+      // the window of the caller (including the old stack pointer) gets
+      // restored anyways.
     } else {
       BuildMI(MBB, I, dl, TII.get(Xtensa::OR), SP).addReg(FP).addReg(FP);
     }


### PR DESCRIPTION
This PR removes the use of an unnecessary MOVSP in the function epilogue (#19 ). Restoring the frame pointer when using Xtensa Windowed Regisers option is not needed because original stack pointer will get restored when returning (goes to register window of caller which contains original stack pointer).

For reference:
`test.c`:
```
int secretpin() {
    return 1337;
}
```

Compiling with `xtensa-esp32-elf-gcc -c test.c`:
```
00000000 <secretpin>:
   0:	004136        	entry	a1, 32
   3:	017d      	mov.n	a7, a1
   5:	39a522        	movi	a2, 0x539
   8:	f01d      	retw.n
```

Compiling with `$LLVM_INSTALL_DIR/bin/clang --target="xtensa-freestanding" -mcpu=esp32 -c test.c`:
```
00000000 <secretpin>:
   0:	004136        	entry	a1, 32
   3:	017d      	mov.n	a7, a1
   5:	39a522        	movi	a2, 0x539
   8:	001710        	movsp	a1, a7
   b:	f01d      	retw.n
```