### PR TITLE
[Xtensa] Fix crash when invoking Clang with assertions enabled

### DIFF
--- a/clang/lib/Driver/ToolChains/Xtensa.cpp
+++ b/clang/lib/Driver/ToolChains/Xtensa.cpp
@@ -38,10 +38,6 @@ XtensaToolChain::XtensaToolChain(const Driver &D, const llvm::Triple &Triple,
 
   GCCInstallation.init(Triple, Args);
 
-  if (!GCCInstallation.isValid()) {
-    llvm_unreachable("Unexpected Xtensa GCC toolchain version");
-  }
-
   Multilibs = GCCInstallation.getMultilibs();
   SelectedMultilib = GCCInstallation.getMultilib();
 


### PR DESCRIPTION
I'm not sure why this assert was inserted here but it results in a crash when assertions are enabled. Removing it doesn't seem to negatively affect anything.

This patch fixes https://github.com/espressif/llvm-project/issues/56.