### PR TITLE
[Xtensa] Fix Clang builtins include directory (LLVM-293)

### DIFF
--- a/clang/lib/Driver/ToolChains/Xtensa.cpp
+++ b/clang/lib/Driver/ToolChains/Xtensa.cpp
@@ -145,28 +145,33 @@ Tool *XtensaToolChain::buildAssembler() const {
 
 void XtensaToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
                                                 ArgStringList &CC1Args) const {
-  if (DriverArgs.hasArg(clang::driver::options::OPT_nostdinc) ||
-      DriverArgs.hasArg(options::OPT_nostdlibinc))
+  if (DriverArgs.hasArg(clang::driver::options::OPT_nostdinc))
     return;
 
-  if (!getDriver().SysRoot.empty()) {
-    SmallString<128> Dir(getDriver().SysRoot);
+  if (!DriverArgs.hasArg(options::OPT_nobuiltininc)) {
+    SmallString<128> Dir(getDriver().ResourceDir);
     llvm::sys::path::append(Dir, "include");
     addSystemInclude(DriverArgs, CC1Args, Dir.str());
-  } else if (GCCInstallation.isValid()) {
-    SmallString<128> Path1(getDriver().ResourceDir);
-    llvm::sys::path::append(Path1, "include");
-    SmallString<128> Path2(GCCToolchainDir);
-    llvm::sys::path::append(Path2, GCCToolchainName, "sys-include");
-    SmallString<128> Path3(GCCToolchainDir);
-    llvm::sys::path::append(Path3, GCCToolchainName, "include");
+  }
 
-    const StringRef Paths[] = {Path1, Path2, Path3};
-    addSystemIncludes(DriverArgs, CC1Args, Paths);
-  } else {
-    SmallString<128> Dir(computeSysRoot());
-    llvm::sys::path::append(Dir, "include");
-    addSystemInclude(DriverArgs, CC1Args, Dir.str());
+  if (!DriverArgs.hasArg(options::OPT_nostdlibinc)) {
+    if (!getDriver().SysRoot.empty()) {
+      SmallString<128> Dir(getDriver().SysRoot);
+      llvm::sys::path::append(Dir, "include");
+      addSystemInclude(DriverArgs, CC1Args, Dir.str());
+    } else if (GCCInstallation.isValid()) {
+      SmallString<128> Path1(GCCToolchainDir);
+      llvm::sys::path::append(Path1, GCCToolchainName, "sys-include");
+      SmallString<128> Path2(GCCToolchainDir);
+      llvm::sys::path::append(Path2, GCCToolchainName, "include");
+
+      const StringRef Paths[] = {Path1, Path2};
+      addSystemIncludes(DriverArgs, CC1Args, Paths);
+    } else {
+      SmallString<128> Dir(computeSysRoot());
+      llvm::sys::path::append(Dir, "include");
+      addSystemInclude(DriverArgs, CC1Args, Dir.str());
+    }
   }
 }
 


### PR DESCRIPTION
This fixes #83.

In short, it adjusts the include path logic to include the builtins directory as long as `-nostdinc` or `-nobuiltininc` isn't specified.
Previously, the builtins directory would not be included if either the GCC installation wasn't found, or `-nostdlibinc` was specified (both of which aren't related to the builtins directory).

I've tested this patch on TinyGo, but didn't test it otherwise.