### PR TITLE
[Xtensa] Implement XtensaNullTargetStreamer

### DIFF
--- a/llvm/lib/Target/Xtensa/AsmParser/XtensaAsmParser.cpp
+++ b/llvm/lib/Target/Xtensa/AsmParser/XtensaAsmParser.cpp
@@ -54,6 +54,8 @@ class XtensaAsmParser : public MCTargetAsmParser {
   SMLoc getLoc() const { return getParser().getTok().getLoc(); }
 
   XtensaTargetStreamer &getTargetStreamer() {
+    assert(getParser().getStreamer().getTargetStreamer() &&
+           "do not have a target streamer");
     MCTargetStreamer &TS = *getParser().getStreamer().getTargetStreamer();
     return static_cast<XtensaTargetStreamer &>(TS);
   }

--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCTargetDesc.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCTargetDesc.cpp
@@ -85,6 +85,10 @@ createXtensaObjectTargetStreamer(MCStreamer &S, const MCSubtargetInfo &STI) {
   return new XtensaTargetELFStreamer(S);
 }
 
+static MCTargetStreamer *createXtensaNullTargetStreamer(MCStreamer &S) {
+  return new XtensaTargetStreamer(S);
+}
+
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeXtensaTargetMC() {
   // Register the MCAsmInfo.
   TargetRegistry::RegisterMCAsmInfo(getTheXtensaTarget(), createXtensaMCAsmInfo);
@@ -119,4 +123,8 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeXtensaTargetMC() {
   // Register the ELF target streamer.
   TargetRegistry::RegisterObjectTargetStreamer(
       getTheXtensaTarget(), createXtensaObjectTargetStreamer);
+
+  // Register the null target streamer.
+  TargetRegistry::RegisterNullTargetStreamer(getTheXtensaTarget(),
+                                              createXtensaNullTargetStreamer);
 }

--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaTargetStreamer.h
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaTargetStreamer.h
@@ -24,10 +24,10 @@ class XtensaTargetStreamer : public MCTargetStreamer {
 
 public:
   XtensaTargetStreamer(MCStreamer &S);
-  virtual void emitLiteral(MCSymbol *LblSym, const MCExpr *Value, SMLoc L) = 0;
-  virtual void emitLiteralLabel(MCSymbol *LblSym, SMLoc L) = 0;
-  virtual void emitLiteral(const MCExpr *Value, SMLoc L) = 0;
-  virtual void emitLiteral(std::string str) = 0;
+  virtual void emitLiteral(MCSymbol *LblSym, const MCExpr *Value, SMLoc L) {};
+  virtual void emitLiteralLabel(MCSymbol *LblSym, SMLoc L) {};
+  virtual void emitLiteral(const MCExpr *Value, SMLoc L) {};
+  virtual void emitLiteral(std::string str) {};
   void setLiteralSectionPrefix(StringRef Name) { LiteralSectionPrefix = Name; }
   StringRef getLiteralSectionPrefix() { return LiteralSectionPrefix; }
 };
@@ -37,9 +37,6 @@ class XtensaTargetAsmStreamer : public XtensaTargetStreamer {
 
 public:
   XtensaTargetAsmStreamer(MCStreamer &S, formatted_raw_ostream &OS);
-  void emitLiteral(MCSymbol *LblSym, const MCExpr *Value, SMLoc L) override {}
-  void emitLiteralLabel(MCSymbol *LblSym, SMLoc L) override {}
-  void emitLiteral(const MCExpr *Value, SMLoc L) override {}
   void emitLiteral(std::string str) override;
 };
 
@@ -50,7 +47,6 @@ public:
   void emitLiteral(MCSymbol *LblSym, const MCExpr *Value, SMLoc L) override;
   void emitLiteralLabel(MCSymbol *LblSym, SMLoc L) override;
   void emitLiteral(const MCExpr *Value, SMLoc L) override;
-  void emitLiteral(std::string str) override {}
 };
 } // end namespace llvm
 


### PR DESCRIPTION
This fixes crash in Xtensa AsmParser run during ModuleSummaryIndexAnalysis pass.
