### PR TITLE
[Xtensa] fix duplicated CPI symbols with text section literals (LLVM-443)

### DIFF
--- a/llvm/lib/Target/Xtensa/XtensaAsmPrinter.cpp
+++ b/llvm/lib/Target/Xtensa/XtensaAsmPrinter.cpp
@@ -171,6 +171,10 @@ void XtensaAsmPrinter::emitMachineConstantPoolEntry(
 // used to print out constants which have been "spilled to memory" by
 // the code generator.
 void XtensaAsmPrinter::emitConstantPool() {
+  auto *ST = &MF->getSubtarget<XtensaSubtarget>();
+  if (ST->useTextSectionLiterals())
+    return;
+
   const Function &F = MF->getFunction();
   const MachineConstantPool *MCP = MF->getConstantPool();
   const std::vector<MachineConstantPoolEntry> &CP = MCP->getConstants();


### PR DESCRIPTION
## Description
see https://github.com/espressif/llvm-project/issues/112

## Related

## Testing

## Checklist

