### PR TITLE
XtensaAsmPrinter: add a missing case for MBB (LLVM-456)

### DIFF
--- a/llvm/lib/Target/Xtensa/XtensaAsmPrinter.cpp
+++ b/llvm/lib/Target/Xtensa/XtensaAsmPrinter.cpp
@@ -103,6 +103,9 @@ void XtensaAsmPrinter::emitMachineConstantPoolValue(
     const BlockAddress *BA =
         cast<XtensaConstantPoolConstant>(ACPV)->getBlockAddress();
     MCSym = GetBlockAddressSymbol(BA);
+  } else if (ACPV->isMachineBasicBlock()) {
+    const MachineBasicBlock *MBB = cast<XtensaConstantPoolMBB>(ACPV)->getMBB();
+    MCSym = MBB->getSymbol();
   } else if (ACPV->isJumpTable()) {
     unsigned Idx = cast<XtensaConstantPoolJumpTable>(ACPV)->getIndex();
     MCSym = this->GetJTISymbol(Idx, false);


### PR DESCRIPTION
fixes an assertion failure:
```
Assertion failed: (ACPV->isExtSymbol() && "unrecognized constant pool value"), function emitMachineConstantPoolValue, file XtensaAsmPrinter.cpp, line 110.
```
observed with wamr-compiler.
