### PR TITLE
[Xtensa] Fix decoding of immediate offsets for ESP32-S3 instructions

### DIFF
--- a/llvm/lib/Target/Xtensa/Disassembler/XtensaDisassembler.cpp
+++ b/llvm/lib/Target/Xtensa/Disassembler/XtensaDisassembler.cpp
@@ -560,55 +560,40 @@ static DecodeStatus decodeSelect_256Operand(MCInst &Inst, uint64_t Imm,
 static DecodeStatus decodeOffset_16_16Operand(MCInst &Inst, uint64_t Imm,
                                               int64_t Address,
                                               const void *Decoder) {
-  assert(isInt<8>(Imm) && "Invalid immediate");
-  if ((Imm & 0xf) != 0)
-    Inst.addOperand(MCOperand::createImm(Imm << 4));
-  else
-    Inst.addOperand(MCOperand::createImm(Imm));
+  assert(isUInt<4>(Imm) && "Invalid immediate");
+  Inst.addOperand(MCOperand::createImm(SignExtend64<8>(Imm << 4)));
   return MCDisassembler::Success;
 }
 
 static DecodeStatus decodeOffset_256_8Operand(MCInst &Inst, uint64_t Imm,
                                               int64_t Address,
                                               const void *Decoder) {
-  assert(isInt<16>(Imm) && "Invalid immediate");
-  if ((Imm & 0x7) != 0)
-    Inst.addOperand(MCOperand::createImm(Imm << 3));
-  else
-    Inst.addOperand(MCOperand::createImm(Imm));
+  assert(isUInt<8>(Imm) && "Invalid immediate");
+  Inst.addOperand(MCOperand::createImm(SignExtend64<11>(Imm << 3)));
   return MCDisassembler::Success;
 }
 
 static DecodeStatus decodeOffset_256_16Operand(MCInst &Inst, uint64_t Imm,
                                                int64_t Address,
                                                const void *Decoder) {
-  assert(isInt<16>(Imm) && "Invalid immediate");
-  if ((Imm & 0xf) != 0)
-    Inst.addOperand(MCOperand::createImm(Imm << 4));
-  else
-    Inst.addOperand(MCOperand::createImm(Imm));
+  assert(isUInt<8>(Imm) && "Invalid immediate");
+  Inst.addOperand(MCOperand::createImm(SignExtend64<12>(Imm << 4)));
   return MCDisassembler::Success;
 }
 
 static DecodeStatus decodeOffset_256_4Operand(MCInst &Inst, uint64_t Imm,
                                               int64_t Address,
                                               const void *Decoder) {
-  assert(isInt<16>(Imm) && "Invalid immediate");
-  if ((Imm & 0x2) != 0)
-    Inst.addOperand(MCOperand::createImm(Imm << 2));
-  else
-    Inst.addOperand(MCOperand::createImm(Imm));
+  assert(isUInt<8>(Imm) && "Invalid immediate");
+  Inst.addOperand(MCOperand::createImm(SignExtend64<10>(Imm << 2)));
   return MCDisassembler::Success;
 }
 
 static DecodeStatus decodeOffset_128_2Operand(MCInst &Inst, uint64_t Imm,
                                               int64_t Address,
                                               const void *Decoder) {
-  assert(isUInt<8>(Imm) && "Invalid immediate");
-  if ((Imm & 0x1) != 0)
-    Inst.addOperand(MCOperand::createImm(Imm << 1));
-  else
-    Inst.addOperand(MCOperand::createImm(Imm));
+  assert(isUInt<7>(Imm) && "Invalid immediate");
+  Inst.addOperand(MCOperand::createImm(Imm << 1));
   return MCDisassembler::Success;
 }
 
@@ -623,11 +608,8 @@ static DecodeStatus decodeOffset_128_1Operand(MCInst &Inst, uint64_t Imm,
 static DecodeStatus decodeOffset_64_16Operand(MCInst &Inst, uint64_t Imm,
                                               int64_t Address,
                                               const void *Decoder) {
-  assert(isInt<16>(Imm) && "Invalid immediate");
-  if ((Imm & 0xf) != 0)
-    Inst.addOperand(MCOperand::createImm(Imm << 4));
-  else
-    Inst.addOperand(MCOperand::createImm(Imm));
+  assert(isUInt<6>(Imm) && "Invalid immediate");
+  Inst.addOperand(MCOperand::createImm(SignExtend64<10>(Imm << 4)));
   return MCDisassembler::Success;
 }
 

--- a/llvm/test/MC/Xtensa/xtensa-esp32s3-scaled-offsets.s
+++ b/llvm/test/MC/Xtensa/xtensa-esp32s3-scaled-offsets.s
@@ -1,0 +1,48 @@
+# RUN: llvm-mc -triple=xtensa -mcpu=esp32s3 -filetype=obj %s -o %t
+# RUN: llvm-objdump -d --mcpu=esp32s3 --no-show-raw-insn %t | FileCheck %s
+
+# offset_16_16
+ee.ldf.128.ip f0, f1, f2, f3, a4, -128
+# CHECK: ee.ldf.128.ip f0, f1, f2, f3, a4, -128
+ee.ldf.128.ip f0, f1, f2, f3, a4, -16
+# CHECK: ee.ldf.128.ip f0, f1, f2, f3, a4, -16
+ee.ldf.128.ip f0, f1, f2, f3, a4, 112
+# CHECK: ee.ldf.128.ip f0, f1, f2, f3, a4, 112
+
+# offset_256_8
+ee.ld.accx.ip a0, -1024
+# CHECK: ee.ld.accx.ip a0, -1024
+ee.ld.accx.ip a0, -8
+# CHECK: ee.ld.accx.ip a0, -8
+ee.ld.accx.ip a0, 1016
+# CHECK: ee.ld.accx.ip a0, 1016
+
+# offset_256_16
+ee.ldqa.s16.128.ip a0, -2048
+# CHECK: ee.ldqa.s16.128.ip a0, -2048
+ee.ldqa.s16.128.ip a0, -16
+# CHECK: ee.ldqa.s16.128.ip a0, -16
+ee.ldqa.s16.128.ip a0, 2032
+# CHECK: ee.ldqa.s16.128.ip a0, 2032
+
+# offset_256_4
+ee.ld.qacc_h.h.32.ip a0, -512
+# CHECK: ee.ld.qacc_h.h.32.ip a0, -512
+ee.ld.qacc_h.h.32.ip a0, -4
+# CHECK: ee.ld.qacc_h.h.32.ip a0, -4
+ee.ld.qacc_h.h.32.ip a0, 508
+# CHECK: ee.ld.qacc_h.h.32.ip a0, 508
+
+# offset_128_2
+ee.vldbc.16.ip q0, a0, 4
+# CHECK: ee.vldbc.16.ip q0, a0, 4
+ee.vldbc.16.ip q0, a0, 254
+# CHECK: ee.vldbc.16.ip q0, a0, 254
+
+# offset_64_16
+ee.vmulas.s16.accx.ld.ip q0, a0, -512, q1, q2
+# CHECK: ee.vmulas.s16.accx.ld.ip q0, a0, -512, q1, q2
+ee.vmulas.s16.accx.ld.ip q0, a0, -16, q1, q2
+# CHECK: ee.vmulas.s16.accx.ld.ip q0, a0, -16, q1, q2
+ee.vmulas.s16.accx.ld.ip q0, a0, 496, q1, q2
+# CHECK: ee.vmulas.s16.accx.ld.ip q0, a0, 496, q1, q2


### PR DESCRIPTION
Hi,

Fixes ESP32-S3 immediate offset decoder behavior. 

They were doing zero-extend while it was supposed to be sign-extend. It was disregarding the sign bit and was causing assertions to fire. Correct behavior is documented in other decoders.
Tightened the bit-width assertions.
Added some tests checking boundaries.
Used the `esp32-s3_technical_reference_manual_en.pdf` as reference.